### PR TITLE
首页Google站内搜索

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,32 @@
                 <div class="loader" ></div>
             </div>
         </div>
-        <div class="clear"></div>    
+        <div class="clear"></div>
+
+    <form method="get" action="http://www.google.com.hk/search" target="google_window">
+    <a href="http://www.google.com.hk/"><img src="http://www.google.com/logos/Logo_25wht.gif" border="0" alt="Google" align="middle"></img></a>
+        <input type="text" name="as_q" size="31" maxlength="255" value=""/>
+        <input type="submit" name="sa" value="搜索"/>
+        <input type="radio" name="as_sitesearch" value="xdlinux.info/wiki" checked="checked"/>
+        <font size="-1" color="#000000">wiki</font>
+        <input type="radio" name="as_sitesearch" value="xdlinux.info/bbs" checked="checked"/>
+        <font size="-1" color="#000000">bbs</font>
+        <input type="radio" name="as_sitesearch" value="groups.google.com/group/xidian_linux" checked="checked"/>
+        <font size="-1" color="#000000">groups(邮件列表)</font>
+        <input type="radio" name="as_sitesearch" value="xdlinux.info" checked="checked"/>
+        <font size="-1" color="#000000">xdlinux全站搜索</font>
+        
+        <input name="newwindow" value="1" type="hidden"/>
+        <input name="complete" value="1" type="hidden"/>
+        <input name="forid" value="zh-CN" type="hidden"/>
+        <input type="hidden" name="num" value="10"/>
+        <input name="btnG" value="Google+%E6%90%9C%E7%B4%A2&amp;" type="hidden"/>
+        <input name="as_ft" value="1" type="hidden"/>
+        <input name="as_qdr" value="all" type="hidden"/>
+        <input name="as_occt" value="any" type="hidden"/>
+        <input name="as_dt" value="i" type="hidden"/>
+    </form>
+    
         <div class="comment"> 
             <div id="disqus_thread"></div>
             <script type="text/javascript">


### PR DESCRIPTION
仿照http://wiki.ubuntu.org.cn 底部的搜索fork成了社区的站内搜索，感觉基本够用了。还需要改进的就是过滤掉m.xdlinux.info的内容，因为这个和xdlinux.info相应页面的内容重了（不过Google默认是不显示重复的内容的）。

对HTML CSS不太熟悉... 所以添加的代码也许还有一些不规范的地方，见谅了^_^
