### PR TITLE
items内title和date不在一行的bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,32 +116,34 @@
             </div>
         </div>
         <div class="clear"></div>
-
-    <form method="get" action="http://www.google.com.hk/search" target="google_window">
-    <a href="http://www.google.com.hk/"><img src="http://www.google.com/logos/Logo_25wht.gif" border="0" alt="Google" align="middle"></img></a>
-        <input type="text" name="as_q" size="31" maxlength="255" value=""/>
-        <input type="submit" name="sa" value="搜索"/>
-        <input type="radio" name="as_sitesearch" value="xdlinux.info/wiki" checked="checked"/>
-        <font size="-1" color="#000000">wiki</font>
-        <input type="radio" name="as_sitesearch" value="xdlinux.info/bbs" checked="checked"/>
-        <font size="-1" color="#000000">bbs</font>
-        <input type="radio" name="as_sitesearch" value="groups.google.com/group/xidian_linux" checked="checked"/>
-        <font size="-1" color="#000000">groups(邮件列表)</font>
-        <input type="radio" name="as_sitesearch" value="xdlinux.info" checked="checked"/>
-        <font size="-1" color="#000000">xdlinux全站搜索</font>
-        
-        <input name="newwindow" value="1" type="hidden"/>
-        <input name="complete" value="1" type="hidden"/>
-        <input name="forid" value="zh-CN" type="hidden"/>
-        <input type="hidden" name="num" value="10"/>
-        <input name="btnG" value="Google+%E6%90%9C%E7%B4%A2&amp;" type="hidden"/>
-        <input name="as_ft" value="1" type="hidden"/>
-        <input name="as_qdr" value="all" type="hidden"/>
-        <input name="as_occt" value="any" type="hidden"/>
-        <input name="as_dt" value="i" type="hidden"/>
-    </form>
-    
-        <div class="comment"> 
+        <!--Google站内搜索开始-->
+        <div>
+        <form method="get" action="http://www.google.com.hk/search" target="google_window">
+        <a href="http://www.google.com.hk/"><img src="http://www.google.com/logos/Logo_25wht.gif" border="0" alt="Google" align="middle"></img></a>
+            <input type="text" name="as_q" size="31" maxlength="255" value=""/>
+            <input type="submit" name="sa" value="搜索"/>
+            <input type="radio" name="as_sitesearch" value="xdlinux.info/wiki" checked="checked"/>
+            <font size="-1" color="#000000">wiki</font>
+            <input type="radio" name="as_sitesearch" value="/bbs" checked="checked"/>
+            <font size="-1" color="#000000">bbs</font>
+            <input type="radio" name="as_sitesearch" value="groups.google.com/group/xidian_linux" checked="checked"/>
+            <font size="-1" color="#000000">邮件列表</font>
+            <input type="radio" name="as_sitesearch" value="xdlinux.info" checked="checked"/>
+            <font size="-1" color="#000000">xdlinux全站搜索</font>
+            
+            <input name="newwindow" value="1" type="hidden"/>
+            <input name="complete" value="1" type="hidden"/>
+            <input name="forid" value="zh-CN" type="hidden"/>
+            <input type="hidden" name="num" value="10"/>
+            <input name="btnG" value="Google+%E6%90%9C%E7%B4%A2&amp;" type="hidden"/>
+            <input name="as_ft" value="1" type="hidden"/>
+            <input name="as_qdr" value="all" type="hidden"/>
+            <input name="as_occt" value="any" type="hidden"/>
+            <input name="as_dt" value="i" type="hidden"/>
+        </form>
+        </div>
+        <!--Google站内搜索结束-->
+        <div class="comment">
             <div id="disqus_thread"></div>
             <script type="text/javascript">
                 var disqus_shortname = 'xdlinux'; // required: replace example with your forum shortname

--- a/index.html
+++ b/index.html
@@ -122,13 +122,13 @@
         <a href="http://www.google.com.hk/"><img src="http://www.google.com/logos/Logo_25wht.gif" border="0" alt="Google" align="middle"></img></a>
             <input type="text" name="as_q" size="31" maxlength="255" value=""/>
             <input type="submit" name="sa" value="搜索"/>
-            <input type="radio" name="as_sitesearch" value="xdlinux.info/wiki" checked="checked"/>
+            <input type="radio" name="as_sitesearch" value="http://xdlinux.info/wiki" checked="checked"/>
             <font size="-1" color="#000000">wiki</font>
-            <input type="radio" name="as_sitesearch" value="/bbs" checked="checked"/>
+            <input type="radio" name="as_sitesearch" value="http://xdlinux.info/bbs" checked="checked"/>
             <font size="-1" color="#000000">bbs</font>
-            <input type="radio" name="as_sitesearch" value="groups.google.com/group/xidian_linux" checked="checked"/>
+            <input type="radio" name="as_sitesearch" value="http://groups.google.com/group/xidian_linux" checked="checked"/>
             <font size="-1" color="#000000">邮件列表</font>
-            <input type="radio" name="as_sitesearch" value="xdlinux.info" checked="checked"/>
+            <input type="radio" name="as_sitesearch" value="http://xdlinux.info" checked="checked"/>
             <font size="-1" color="#000000">xdlinux全站搜索</font>
             
             <input name="newwindow" value="1" type="hidden"/>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -243,7 +243,7 @@ text-decoration:none;
 }
 .items .title {
   float:left;
-  width: 15em;
+  width: 14em;
 }
 .items .date {
   float:right;


### PR DESCRIPTION
- 由于「Wiki更新」一栏的更新日期过久，出现了「约一个月前」这种较宽的「date」，将.items .title的width改为14em即可。
- 可不可以考虑加入鼠标移至相应的「title」时自动弹出「title」的全名的代码？这样就能方便地看到一些较长的标题
